### PR TITLE
Fix stale unit test, make failures more readable

### DIFF
--- a/pkg/provisioner/helpers_test.go
+++ b/pkg/provisioner/helpers_test.go
@@ -18,10 +18,11 @@ package provisioner
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/fake"
@@ -110,7 +111,7 @@ func Test_objectBucketClaimReconciler_shouldProvision(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			if got := shouldProvision(tt.args.obc); got != tt.want {
-				t.Errorf("ObjectBucketClaimReconciler.shouldProvision() = %v, want %v", got, tt.want)
+				t.Errorf("want = %v, got %v", tt.want, got)
 			}
 		})
 	}
@@ -157,18 +158,18 @@ func Test_objectBucketClaimReconciler_claimFromKey(t *testing.T) {
 
 		if tt.want != nil {
 			if _, err = ec.ObjectbucketV1alpha1().ObjectBucketClaims(tt.want.Namespace).Create(tt.want); err != nil {
-				t.Errorf("ObjectBucketClaimReconciler.claimForKey() error = %v,", fmt.Sprintf("error precreating object: %v", err))
+				t.Errorf("error precreating object: %v", err)
 			}
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := claimForKey(tt.args.key, ec)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ObjectBucketClaimReconciler.claimForKey() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("wantErr %v, error = %v", tt.wantErr, err)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ObjectBucketClaimReconciler.claimForKey() = %v, want %v", got, tt.want)
+			if !cmp.Equal(tt.want, got) {
+				t.Errorf(cmp.Diff(tt.want, got))
 			}
 		})
 	}
@@ -280,11 +281,11 @@ func TestStorageClassForClaim(t *testing.T) {
 
 			got, err := storageClassForClaim(tt.args.client, tt.args.obc)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("StorageClassForClaim() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("wantErr %v, error = %v ", tt.wantErr, err)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("StorageClassForClaim() = %v, want %v", got, tt.want)
+			if !cmp.Equal(tt.want, got) {
+				t.Errorf(cmp.Diff(tt.want, got))
 			}
 		})
 	}
@@ -328,12 +329,12 @@ func TestGenerateBucketName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := generateBucketName(tt.args.prefix)
 			if len(got) > maxNameLen {
-				t.Errorf("GenerateName() wanted len <= %d, got len %d", maxNameLen, len(got))
+				t.Errorf("wanted len <= %d, got len %d", maxNameLen, len(got))
 			}
 			if match, err := regexp.MatchString(pattern, got); err != nil {
 				t.Errorf("error matching pattern: %v", err)
 			} else if !match {
-				t.Errorf("GenerateName() want match: %v, got %v", pattern, got)
+				t.Errorf("want match: %v, got %v", pattern, got)
 			}
 		})
 	}

--- a/pkg/provisioner/resourcehandlers_test.go
+++ b/pkg/provisioner/resourcehandlers_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package provisioner
 
 import (
-	"encoding/json"
-	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -37,11 +37,21 @@ func TestNewCredentialsSecret(t *testing.T) {
 		authSecret   = "test-auth-secret"
 	)
 
+	var T = true
+
 	testObjectMeta := metav1.ObjectMeta{
-		Name:      obcName,
-		Namespace: obcNamespace,
-		Finalizers: []string{
-			finalizer,
+		Name:       obcName,
+		Namespace:  obcNamespace,
+		Finalizers: []string{finalizer},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         "objectbucket.io/v1alpha1",
+				Kind:               "ObjectBucketClaim",
+				Name:               obcName,
+				UID:                "",
+				Controller:         &T,
+				BlockOwnerDeletion: &T,
+			},
 		},
 	}
 
@@ -127,8 +137,8 @@ func TestNewCredentialsSecret(t *testing.T) {
 				t.Errorf("NewCredentailsSecret() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewCredentailsSecret() = %v, want %v", got, tt.want)
+			if !cmp.Equal(tt.want, got) {
+				t.Errorf(cmp.Diff(tt.want, got))
 			}
 		})
 	}
@@ -137,6 +147,7 @@ func TestNewCredentialsSecret(t *testing.T) {
 func TestNewBucketConfigMap(t *testing.T) {
 
 	const (
+		obcName   = "test-obc"
 		host      = "http://www.test.com"
 		name      = "bucket-name"
 		port      = 11111
@@ -144,11 +155,23 @@ func TestNewBucketConfigMap(t *testing.T) {
 		region    = "region"
 		subRegion = "sub-region"
 	)
+	var T = true
 
 	objMeta := metav1.ObjectMeta{
 		Name:       "test-obc",
 		Namespace:  "test-obc-namespace",
 		Finalizers: []string{finalizer},
+		Labels:     nil,
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         "objectbucket.io/v1alpha1",
+				Kind:               "ObjectBucketClaim",
+				Name:               obcName,
+				UID:                "",
+				Controller:         &T,
+				BlockOwnerDeletion: &T,
+			},
+		},
 	}
 
 	type args struct {
@@ -264,10 +287,8 @@ func TestNewBucketConfigMap(t *testing.T) {
 			got, err := newBucketConfigMap(tt.args.ep, tt.args.obc)
 			if (err != nil) == !tt.wantErr {
 				t.Errorf("newBucketConfigMap() error = %v, wantErr %v", err, tt.wantErr)
-			} else if !reflect.DeepEqual(got, tt.want) {
-				gotjson, _ := json.MarshalIndent(got, "", "\t")
-				wantjson, _ := json.MarshalIndent(tt.want, "", "\t")
-				t.Errorf("newBucketConfigMap() = %v, want %v", string(gotjson), string(wantjson))
+			} else if !cmp.Equal(tt.want, got) {
+				t.Errorf(cmp.Diff(tt.want, got))
 			}
 		})
 	}


### PR DESCRIPTION
Fixes ownerReference mismatch in unit tests' expected vs returned objects.

Replace `reflect` pkg with `github.com/google/go-cmp` for safer and much more readable test output.